### PR TITLE
Remove kz from Europe

### DIFF
--- a/pygal_maps_world/i18n.py
+++ b/pygal_maps_world/i18n.py
@@ -207,7 +207,7 @@ ASIA = [
 
 EUROPE = [
     'ad', 'al', 'am', 'at', 'az', 'be', 'by', 'ba', 'bg', 'hr', 'cy', 'cz',
-    'dk', 'ee', 'fi', 'fr', 'ge', 'de', 'gr', 'hu', 'is', 'ie', 'it', 'kz',
+    'dk', 'ee', 'fi', 'fr', 'ge', 'de', 'gr', 'hu', 'is', 'ie', 'it',
     'lv', 'li', 'lt', 'lu', 'mk', 'mt', 'md', 'mc', 'me', 'nl', 'no', 'pl',
     'pt', 'ro', 'ru', 'sm', 'rs', 'sk', 'si', 'es', 'se', 'ch', 'tr', 'ua',
     'gb', 'va'


### PR DESCRIPTION
kz was both in Europe and Asia. It is geographically in Asia.